### PR TITLE
使用添加属性的方式实现vue style的scope支持

### DIFF
--- a/lib/loader/style.js
+++ b/lib/loader/style.js
@@ -3,8 +3,44 @@ var fs = require('fs');
 var path = require('path');
 var postcss = require('postcss');
 var recast = require('recast');
+var selectorParser = require('postcss-selector-parser');
 
 var template = fs.readFileSync(path.resolve(__dirname, './templates/styleScript.js'));
+
+var addId = postcss.plugin('add-id', function(opts) {
+  return function(root) {
+    root.each(function rewriteSelector(node) {
+      if (!node.selector) {
+        // handle media queries
+        if (node.type === 'atrule' && node.name === 'media') {
+          node.each(rewriteSelector);
+        }
+        return;
+      }
+      node.selector = selectorParser(function(selectors) {
+        selectors.each(function(selector) {
+          var node = null;
+          selector.each(function(n) {
+            if (n.type !== 'pseudo') node = n;
+          });
+          selector.insertAfter(node, selectorParser.attribute({
+            attribute: opts.id
+          }));
+        });
+      }).process(node.selector).result;
+    });
+  };
+});
+
+var trim = postcss.plugin('trim', function() {
+  return function(css) {
+    css.walk(function(node) {
+      if (node.type === 'rule' || node.type === 'atrule') {
+        node.raws.before = node.raws.after = '\n';
+      }
+    });
+  };
+});
 
 function processModule(idInfo, module) {
   return new Promise(function(resolve, reject) {
@@ -15,20 +51,29 @@ function processModule(idInfo, module) {
       modules: '{}',
     };
 
-    if (!idInfo.module) {
+    if (!idInfo.module && !idInfo.scoped) {
       return resolve(out);
     }
 
-    out.dest = module.src + '.module.js';
+    var plugins = [trim];
 
-    var cssModulePlugin = require('postcss-modules')({
-      generateScopedName: '[path][name]__[local]',
-      getJSON: function(cssFileName, json) {
-        out.modules = JSON.stringify(json);
-      }
-    });
+    if (idInfo.module) {
+      out.dest = module.src + '.module.js';
+      var cssModulePlugin = require('postcss-modules')({
+        generateScopedName: '[path][name]__[local]',
+        getJSON: function(cssFileName, json) {
+          out.modules = JSON.stringify(json);
+        }
+      });
+      plugins.push(cssModulePlugin);
+    }
 
-    postcss([ cssModulePlugin ])
+    if (idInfo.scoped) {
+      plugins.push(addId({id: idInfo.scoped}));
+      out.dest = module.src + '.scoped.js';
+    }
+
+    postcss(plugins)
       .process(out.contents, { from: module.src })
       .then(function(result) {
         out.contents = result.css;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "path-is-absolute": "1.0.0",
     "postcss": "^5.1.2",
     "postcss-modules": "^0.5.0",
+    "postcss-selector-parser": "^2.2.3",
     "recast": "0.10.43"
   },
   "devDependencies": {


### PR DESCRIPTION
```
<script>
import style from './style.css#scoped=foo-bar';
style.use();
</script>

<template>
<div class="test" foo-bar></div>
</template>
```

style.css:
```
.test{
  color: red;
}
```

==>

```
.test[foo-bar]{
  color: red;
}
```

miaow-vue-parse中使用此特性实现vue组件的scoped style。